### PR TITLE
build: Add gradle-wrapper.properties for Gradle 8.2

### DIFF
--- a/TodoListApp/gradle/wrapper/gradle-wrapper.properties
+++ b/TodoListApp/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,5 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-all.zip
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists


### PR DESCRIPTION
I created the gradle-wrapper.properties file to ensure the project uses Gradle version 8.2, addressing potential build issues for you if you are on a different Gradle version.